### PR TITLE
Feature/drift fx

### DIFF
--- a/core/src/commonMain/kotlin/info/laht/threekt/WindowSize.kt
+++ b/core/src/commonMain/kotlin/info/laht/threekt/WindowSize.kt
@@ -4,8 +4,8 @@ import info.laht.threekt.math.Vector2
 import kotlin.jvm.JvmOverloads
 
 data class WindowSize(
-        var width: Int,
-        var height: Int
+    var width: Int,
+    var height: Int
 ) {
 
     val aspect: Float

--- a/core/src/jvmMain/kotlin/info/laht/threekt/renderers/GLRenderer.kt
+++ b/core/src/jvmMain/kotlin/info/laht/threekt/renderers/GLRenderer.kt
@@ -32,7 +32,7 @@ class GLRenderer(
         size: WindowSize
 ) : Renderer {
 
-    constructor(height: Int, width: Int) : this(WindowSize(height, width))
+    constructor(width: Int, height: Int) : this(WindowSize(width, height))
 
     var checkShaderErrors = false
     private val capabilities = GLCapabilities()

--- a/core/src/jvmMain/kotlin/info/laht/threekt/renderers/GLRenderer.kt
+++ b/core/src/jvmMain/kotlin/info/laht/threekt/renderers/GLRenderer.kt
@@ -32,6 +32,8 @@ class GLRenderer(
         size: WindowSize
 ) : Renderer {
 
+    constructor(height: Int, width: Int) : this(WindowSize(height, width))
+
     var checkShaderErrors = false
     private val capabilities = GLCapabilities()
     internal val state = GLState()

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -6,9 +6,18 @@ plugins {
 
 repositories {
     maven(url="http://maven.cuchazinteractive.com")
+    maven(url="https://repo.eclipse.org/content/groups/efxclipse")
 }
 
 val kotlinIOVersion = "0.1.16"
+
+val os = org.gradle.internal.os.OperatingSystem.current()
+val lwjglNatives = when {
+    os.isLinux -> "natives-linux"
+    os.isUnix -> "natives-macos"
+    os.isWindows -> "natives-windows"
+    else -> TODO("OS $os not supported")
+}
 
 dependencies {
 
@@ -17,9 +26,20 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-io:$kotlinIOVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-io-jvm:$kotlinIOVersion")
 
+    // JFXGL
     implementation("cuchaz:jfxgl:0.4")
     implementation("cuchaz:jfxgl-jfxrt:0.4")
 
+    // DriftFX
+    val lwjglVersion = "3.2.3"
+    implementation("org.lwjgl:lwjgl:$lwjglVersion")
+    implementation("org.lwjgl:lwjgl-glfw:$lwjglVersion")
+    implementation("org.lwjgl:lwjgl-opengl:$lwjglVersion")
+    runtimeOnly("org.lwjgl:lwjgl:$lwjglVersion:$lwjglNatives")
+    runtimeOnly("org.lwjgl:lwjgl-glfw:$lwjglVersion:$lwjglNatives")
+    runtimeOnly("org.lwjgl:lwjgl-opengl:$lwjglVersion:$lwjglNatives")
+
+    api("org.eclipse.fx:org.eclipse.fx.drift:999.0.0-SNAPSHOT")
 }
 
 tasks {

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     runtimeOnly("org.lwjgl:lwjgl-glfw:$lwjglVersion:$lwjglNatives")
     runtimeOnly("org.lwjgl:lwjgl-opengl:$lwjglVersion:$lwjglNatives")
 
-    api("org.eclipse.fx:org.eclipse.fx.drift:999.0.0-SNAPSHOT")
+    api("org.eclipse.fx:org.eclipse.fx.drift:1.0.0.rc4")
 }
 
 tasks {

--- a/examples/src/main/kotlin/info/laht/threekt/examples/javafx/DriftFxSurfaceRenderer.kt
+++ b/examples/src/main/kotlin/info/laht/threekt/examples/javafx/DriftFxSurfaceRenderer.kt
@@ -1,0 +1,151 @@
+package info.laht.threekt.examples.javafx
+
+import info.laht.threekt.*
+import info.laht.threekt.input.AbstractPeripheralsEventSource
+import info.laht.threekt.input.MouseEventImpl
+import info.laht.threekt.input.MouseWheelEventImpl
+import org.eclipse.fx.drift.*
+import org.eclipse.fx.drift.internal.GL
+import org.lwjgl.opengl.*
+import org.lwjgl.system.Callback
+import java.awt.image.BufferedImage
+import java.io.Closeable
+import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicBoolean
+
+// info.laht.threekt.Window is part of threekt core so we can use it here to avoid duplicate code
+class DriftFxSurfaceRenderer(surface: DriftFXSurface):
+    AbstractPeripheralsEventSource(), Closeable {
+
+    private val driftFxRenderer = GLRenderer.getRenderer(surface)
+
+    private val curWidth = 0
+    private val curHeight = 0
+    private var fbo = 0
+    private var depthTex = 0
+
+    private val context = GL.createContext(0, 3, 2)
+
+    override val size = WindowSize(surface.width.toInt(), surface.height.toInt())
+
+    val aspect: Float
+        get() = size.aspect
+
+    private var debugProc: Callback? = null
+
+    private var windowResizeCallback: WindowResizeListener? = null
+
+    @JvmField
+    var onCloseCallback: WindowClosingCallback? = null
+
+    private var running = true
+
+    fun initialize() {
+        // make context current
+        GL.makeContextCurrent(context)
+        org.lwjgl.opengl.GL.createCapabilities()
+
+        // threekt defaults
+        GL11.glEnable(GL32.GL_PROGRAM_POINT_SIZE)
+        GL11.glEnable(GL20.GL_POINT_SPRITE)
+
+        fbo = GL30.glGenFramebuffers()
+        depthTex = GL11.glGenTextures()
+        //		glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+        //		glFramebufferTexture(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, depthTex, 0);
+    }
+
+    private fun check() {
+        val status = GL30.glCheckFramebufferStatus(GL30.GL_FRAMEBUFFER)
+        when (status) {
+            GL30.GL_FRAMEBUFFER_COMPLETE -> { }
+            GL30.GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT -> System.err.println("INCOMPLETE_ATTACHMENT!")
+        }
+    }
+
+    private fun bind() {
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fbo)
+    }
+
+    private fun unbind() {
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0)
+    }
+
+    private fun dispose() {
+        GL30.glDeleteFramebuffers(fbo)
+        GL11.glDeleteTextures(depthTex)
+        debugProc?.free()
+        org.lwjgl.opengl.GL.setCapabilities(null)
+        GL.destroyContext(context)
+    }
+
+    private fun updateDepthTexSize(size: Vec2i) {
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, depthTex)
+        GL11.glTexImage2D(
+            GL11.GL_TEXTURE_2D,
+            0,
+            GL30.GL_DEPTH_COMPONENT32F,
+            size.x,
+            size.y,
+            0,
+            GL11.GL_DEPTH_COMPONENT,
+            GL11.GL_FLOAT,
+            null as ByteBuffer?
+        )
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, 0)
+    }
+
+    private fun updateFBO(size: Vec2i, target: RenderTarget?) {
+        val targetTex = GLRenderer.getGLTextureId(target)
+        if (size.x != curWidth || size.y != curHeight) {
+            updateDepthTexSize(size)
+        }
+        GL30.glBindFramebuffer(GL30.GL_FRAMEBUFFER, fbo)
+        GL32.glFramebufferTexture(GL30.GL_FRAMEBUFFER, GL30.GL_COLOR_ATTACHMENT0, targetTex, 0)
+        GL32.glFramebufferTexture(GL30.GL_FRAMEBUFFER, GL30.GL_DEPTH_ATTACHMENT, depthTex, 0)
+    }
+
+    fun onWindowResize(listener: WindowResizeListener) {
+        windowResizeCallback = listener
+    }
+
+    fun enableDebugCallback() {
+        debugProc = GLUtil.setupDebugMessageCallback()
+    }
+
+    fun animate(unit: () -> Unit) {
+        val swapChain: Swapchain
+        try {
+            swapChain = driftFxRenderer.createSwapchain(SwapchainConfig(driftFxRenderer.size, 2, PresentationMode.MAILBOX, StandardTransferTypes.MainMemory))
+        } catch (e: Exception) {
+            System.err.println("swapchain creation failed! " + e.message)
+            e.printStackTrace(System.err)
+            return
+        }
+        val renderTarget = swapChain.acquire()
+
+        var lastSize = Vec2i(0, 0)
+        while(running) {
+            if (lastSize.x != driftFxRenderer.size.x || lastSize.y != driftFxRenderer.size.y) {
+                updateFBO(driftFxRenderer.size, renderTarget)
+                lastSize = driftFxRenderer.size
+                windowResizeCallback?.onWindowResize(lastSize.x, lastSize.y)
+            }
+            bind()
+
+            unit()
+
+            unbind()
+            swapChain.present(renderTarget)
+            Thread.sleep(0)
+        }
+
+        swapChain?.dispose()
+        dispose()
+    }
+
+    override fun close() {
+        running = false
+    }
+
+}

--- a/examples/src/main/kotlin/info/laht/threekt/examples/javafx/HelloDriftFX.kt
+++ b/examples/src/main/kotlin/info/laht/threekt/examples/javafx/HelloDriftFX.kt
@@ -1,0 +1,151 @@
+package info.laht.threekt.examples.javafx
+
+import info.laht.threekt.Side
+import info.laht.threekt.WindowSize
+import info.laht.threekt.cameras.PerspectiveCamera
+import info.laht.threekt.core.Clock
+import info.laht.threekt.geometries.BoxBufferGeometry
+import info.laht.threekt.geometries.CylinderBufferGeometry
+import info.laht.threekt.geometries.PlaneBufferGeometry
+import info.laht.threekt.materials.MeshBasicMaterial
+import info.laht.threekt.math.Color
+import info.laht.threekt.math.DEG2RAD
+import info.laht.threekt.objects.Mesh
+import info.laht.threekt.renderers.GLRenderer
+import info.laht.threekt.scenes.Scene
+import javafx.application.Application
+import javafx.event.EventHandler
+import javafx.scene.control.CheckBox
+import javafx.scene.layout.BorderPane
+import javafx.scene.layout.VBox
+import javafx.stage.Stage
+import org.eclipse.fx.drift.DriftFXSurface
+
+fun main() {
+    Application.launch(HelloDriftFX::class.java)
+}
+
+class HelloDriftFX : Application() {
+
+    private val driftFxSurface1 = DriftFXSurface()
+    private val driftFxSurfaceRenderer1 = DriftFxSurfaceRenderer(driftFxSurface1)
+
+    private val driftFxSurface2 = DriftFXSurface()
+    private val driftFxSurfaceRenderer2 = DriftFxSurfaceRenderer(driftFxSurface2)
+
+    private val mesh1: Mesh
+    private val mesh2: Mesh
+
+    init {
+        driftFxSurface1.prefWidth = 300.0
+        driftFxSurface1.prefHeight = 200.0
+
+        driftFxSurface2.prefWidth = 400.0
+        driftFxSurface2.prefHeight = 200.0
+
+        mesh1 = Mesh(BoxBufferGeometry(1f), MeshBasicMaterial().apply {
+            color.set(0x00ff00)
+        })
+
+        mesh2 = Mesh(CylinderBufferGeometry(), MeshBasicMaterial().apply {
+            color.set(0x0000ff)
+        })
+    }
+
+    override fun start(stage: Stage) {
+        val border = BorderPane()
+        stage.scene = javafx.scene.Scene(border, 800.0, 500.0)
+
+        val checkBox1 = CheckBox("Show cube")
+        checkBox1.onAction = EventHandler { event ->
+            mesh1.visible = (event.source as CheckBox).isSelected
+        }
+        checkBox1.isSelected = mesh1.visible
+
+        val checkBox2 = CheckBox("Show cylinder")
+        checkBox2.onAction = EventHandler { event ->
+            mesh2.visible = (event.source as CheckBox).isSelected
+        }
+        checkBox2.isSelected = mesh1.visible
+
+        border.left = VBox(checkBox2, checkBox1)
+        border.center = driftFxSurface2
+        border.right = driftFxSurface1
+
+        stage.setOnCloseRequest {
+            driftFxSurfaceRenderer1.close()
+            driftFxSurfaceRenderer2.close()
+        }
+
+        stage.show()
+
+        // render multiple surfaces :)
+
+        Thread {
+            driftFxSurfaceRenderer1.initialize()
+            renderThree1()
+        }.start()
+
+        Thread {
+            driftFxSurfaceRenderer2.initialize()
+            renderThree2()
+        }.start()
+    }
+
+    private fun renderThree1() {
+        val scene = Scene().apply {
+            setBackground(Color.aliceblue)
+            add(mesh1)
+        }
+        val camera = PerspectiveCamera().apply {
+            position.z = 10f
+        }
+
+        Mesh(PlaneBufferGeometry(10f), MeshBasicMaterial().apply {
+            color.set(Color.gray)
+            side = Side.Double
+        }).also {
+            it.rotation.x = DEG2RAD * -90
+            it.translateZ(-1f)
+            scene.add(it)
+        }
+
+        val renderer = GLRenderer(WindowSize(driftFxSurface1.width.toInt(), driftFxSurface1.height.toInt()))
+
+        val clock = Clock()
+        driftFxSurfaceRenderer1.animate {
+            mesh1.rotation.y += 1f * clock.getDelta()
+
+            renderer.render(scene, camera)
+        }
+    }
+
+    private fun renderThree2() {
+        val scene = Scene().apply {
+            setBackground(Color.orangered)
+            add(mesh2)
+        }
+        val camera = PerspectiveCamera().apply {
+            position.z = 10f
+        }
+
+        Mesh(PlaneBufferGeometry(10f), MeshBasicMaterial().apply {
+            color.set(Color.green)
+            side = Side.Double
+        }).also {
+            it.rotation.x = DEG2RAD * -90
+            it.translateZ(-1f)
+            scene.add(it)
+        }
+
+        val renderer = GLRenderer(WindowSize(driftFxSurface2.width.toInt(), driftFxSurface2.height.toInt()))
+
+        val clock = Clock()
+        driftFxSurfaceRenderer2.animate {
+            mesh2.rotation.y += 1f * clock.getDelta()
+
+            renderer.render(scene, camera)
+        }
+    }
+
+}

--- a/examples/src/main/kotlin/info/laht/threekt/examples/javafx/HelloDriftFX.kt
+++ b/examples/src/main/kotlin/info/laht/threekt/examples/javafx/HelloDriftFX.kt
@@ -1,7 +1,6 @@
 package info.laht.threekt.examples.javafx
 
 import info.laht.threekt.Side
-import info.laht.threekt.WindowSize
 import info.laht.threekt.cameras.PerspectiveCamera
 import info.laht.threekt.core.Clock
 import info.laht.threekt.geometries.BoxBufferGeometry
@@ -23,6 +22,7 @@ import javafx.scene.layout.HBox
 import javafx.scene.layout.VBox
 import javafx.stage.Stage
 import org.eclipse.fx.drift.DriftFXSurface
+import kotlin.concurrent.thread
 
 fun main() {
     Application.launch(HelloDriftFX::class.java)
@@ -87,16 +87,16 @@ class HelloDriftFX : Application() {
 
         // render multiple surfaces :)
 
-        Thread {
+        thread(start = true) {
             driftFxSurfaceRenderer1.initialize()
             driftFxSurfaceRenderer1.enableDebugCallback()
             renderThree1()
-        }.start()
+        }
 
-        Thread {
+        thread(start = true) {
             driftFxSurfaceRenderer2.initialize()
             renderThree2()
-        }.start()
+        }
     }
 
     private fun renderThree1() {
@@ -117,7 +117,7 @@ class HelloDriftFX : Application() {
             scene.add(it)
         }
 
-        val renderer = GLRenderer(WindowSize(driftFxSurface1.width.toInt(), driftFxSurface1.height.toInt()))
+        val renderer = GLRenderer(driftFxSurface1.width.toInt(), driftFxSurface1.height.toInt())
 
         val clock = Clock()
         driftFxSurfaceRenderer1.animate {
@@ -145,7 +145,7 @@ class HelloDriftFX : Application() {
             scene.add(it)
         }
 
-        val renderer = GLRenderer(WindowSize(driftFxSurface2.width.toInt(), driftFxSurface2.height.toInt()))
+        val renderer = GLRenderer(driftFxSurface2.width.toInt(), driftFxSurface2.height.toInt())
 
         val clock = Clock()
 
@@ -172,7 +172,7 @@ class HelloDriftFX : Application() {
         }
         stage.show()
 
-        Thread {
+        thread(start = true) {
             driftFxSurfaceRenderer3.initialize()
 
             val scene = Scene().apply {
@@ -191,7 +191,7 @@ class HelloDriftFX : Application() {
             val sphere = Mesh(geometry, material)
             scene.add(sphere)
 
-            val renderer = GLRenderer(WindowSize(driftFxSurface3.width.toInt(), driftFxSurface3.height.toInt()))
+            val renderer = GLRenderer(driftFxSurface3.width.toInt(), driftFxSurface3.height.toInt())
 
             val clock = Clock()
 
@@ -200,7 +200,7 @@ class HelloDriftFX : Application() {
 
                 renderer.render(scene, camera)
             }
-        }.start()
+        }
     }
 
 }

--- a/examples/src/main/kotlin/info/laht/threekt/examples/javafx/HelloDriftFX.kt
+++ b/examples/src/main/kotlin/info/laht/threekt/examples/javafx/HelloDriftFX.kt
@@ -154,7 +154,7 @@ class HelloDriftFX : Application() {
         }
 
         driftFxSurfaceRenderer2.animate {
-            mesh2.rotation.y += 1f * clock.getDelta()
+            mesh2.rotation.x += 1f * clock.getDelta()
 
             renderer.render(scene, camera)
         }


### PR DESCRIPTION
DriftFX allows you to render any OpenGL content directly into JavaFX nodes. Direct means that there is no transfer between GPU and main memory. The textures never leave the GPU.

This example puts threekt to the test. It renders multiple surfaces (FX nodes) in multiple threads by multiple threekt renderers (also in new windows!). It works great so far.

![Mme4TeTTtW](https://user-images.githubusercontent.com/12080880/114739637-5938cc00-9d49-11eb-9ea3-b0e64f874245.png)

However, I found one small issue which is outside of this PR, but is linked to threekt. I'll post it below this PR.