### PR TITLE
Support alpha (opacity) for vertex colors

### DIFF
--- a/core/src/main/kotlin/info/laht/threekt/renderers/GLRenderer.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/GLRenderer.kt
@@ -1,9 +1,6 @@
 package info.laht.threekt.renderers
 
-import info.laht.threekt.DrawMode
-import info.laht.threekt.Side
-import info.laht.threekt.ToneMapping
-import info.laht.threekt.WindowSize
+import info.laht.threekt.*
 import info.laht.threekt.cameras.Camera
 import info.laht.threekt.core.*
 import info.laht.threekt.extras.objects.ImmediateRenderObject
@@ -927,6 +924,8 @@ class GLRenderer(
 
         }
 
+        materialProperties["vertexAlphas"] = parameters.vertexAlphas
+
         materialProperties["fog"] = fog
 
         // store the light setup it was created for
@@ -964,6 +963,8 @@ class GLRenderer(
     private fun setProgram(camera: Camera, fog: _Fog?, material: Material, `object`: Object3D): GLProgram {
 
         textures.resetTextureUnits()
+
+        val vertexAlphas = material.vertexColors == Colors.Vertex && `object` is GeometryObject && `object`.geometry.attributes.color?.itemSize == 4
 
         val materialProperties = properties[material]
         val lights = currentRenderState!!.lights
@@ -1009,6 +1010,8 @@ class GLRenderer(
 
                 material.needsUpdate = true
 
+            } else if (materialProperties["vertexAlphas"] != vertexAlphas) {
+                material.needsUpdate = true
             }
 
         }

--- a/core/src/main/kotlin/info/laht/threekt/renderers/opengl/GLProgram.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/opengl/GLProgram.kt
@@ -148,6 +148,7 @@ internal class GLProgram(
 
                     if (parameters.vertexTangents) "#define USE_TANGENT" else "",
                     if (parameters.vertexColors.value > 0) "#define USE_COLOR" else "",
+                    if (parameters.vertexAlphas) "#define USE_COLOR_ALPHA" else "",
 
                     if (parameters.flatShading) "#define FLAT_SHADED" else "",
 
@@ -189,9 +190,13 @@ internal class GLProgram(
 
                     "#endif",
 
-                    "#ifdef USE_COLOR",
+                    "#if defined( USE_COLOR_ALPHA )",
 
-                    "	attribute vec3 color;",
+                    "   attribute vec4 color;",
+
+                    "#elif defined( USE_COLOR )",
+
+                    "   attribute vec3 color;",
 
                     "#endif",
 
@@ -266,6 +271,7 @@ internal class GLProgram(
 
                     if (parameters.vertexTangents) "#define USE_TANGENT" else "",
                     if (parameters.vertexColors.value > 0 || parameters.instancingColor) "#define USE_COLOR" else "",
+                    if (parameters.vertexAlphas) "#define USE_COLOR_ALPHA" else "",
 
                     if (parameters.gradientMap) "#define USE_GRADIENTMAP" else "",
 

--- a/core/src/main/kotlin/info/laht/threekt/renderers/opengl/GLPrograms.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/opengl/GLPrograms.kt
@@ -1,9 +1,7 @@
 package info.laht.threekt.renderers.opengl
 
-import info.laht.threekt.NormalMapType
-import info.laht.threekt.Side
-import info.laht.threekt.TextureEncoding
-import info.laht.threekt.TextureMapping
+import info.laht.threekt.*
+import info.laht.threekt.core.GeometryObject
 import info.laht.threekt.core.Object3D
 import info.laht.threekt.core.Shader
 import info.laht.threekt.materials.*
@@ -257,6 +255,7 @@ internal class GLPrograms(
         val flipSided = material.side == Side.Back
 
         val depthPacking = if (material is MeshDepthMaterial) material.depthPacking else false
+        val vertexAlphas = material.vertexColors == Colors.Vertex && `object` is GeometryObject && `object`.geometry.attributes.color?.itemSize == 4
 
         operator fun get(name: String): String? {
             return Parameters::class.java.getDeclaredField(name)?.get(this).toString()
@@ -293,6 +292,7 @@ private val parameterNames = listOf(
     "alphaMap",
     "combine",
     "vertexColors",
+    "vertexAlphas",
     "vertexTangents",
     "fog",
     "useFog",

--- a/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_fragment.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_fragment.kt
@@ -2,7 +2,11 @@ package info.laht.threekt.renderers.shaders.chunk
 
 internal val __color_fragment = """ 
  
-#ifdef USE_COLOR
+#if defined( USE_COLOR_ALPHA )
+
+	diffuseColor *= vColor;
+
+#elif defined( USE_COLOR )
 
 	diffuseColor.rgb *= vColor;
 

--- a/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_pars_fragment.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_pars_fragment.kt
@@ -1,8 +1,12 @@
 package info.laht.threekt.renderers.shaders.chunk
 
 internal val __color_pars_fragment = """ 
- 
-#ifdef USE_COLOR
+
+#if defined( USE_COLOR_ALPHA )
+
+	varying vec4 vColor;
+
+#elif defined( USE_COLOR )
 
 	varying vec3 vColor;
 

--- a/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_pars_vertex.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_pars_vertex.kt
@@ -1,8 +1,12 @@
 package info.laht.threekt.renderers.shaders.chunk
 
 internal val __color_pars_vertex = """ 
- 
-#if defined( USE_COLOR ) || defined( USE_INSTANCING_COLOR )
+
+#if defined( USE_COLOR_ALPHA )
+
+	varying vec4 vColor;
+
+#elif defined( USE_COLOR ) || defined( USE_INSTANCING_COLOR )
 
 	varying vec3 vColor;
 

--- a/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_vertex.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/shaders/chunk/color_vertex.kt
@@ -2,7 +2,11 @@ package info.laht.threekt.renderers.shaders.chunk
 
 internal val __color_vertex = """ 
  
-#if defined( USE_COLOR ) || defined( USE_INSTANCING_COLOR )
+#if defined( USE_COLOR_ALPHA )
+
+	vColor = vec4( 1.0 );
+
+#elif defined( USE_COLOR ) || defined( USE_INSTANCING_COLOR )
 
 	vColor = vec3( 1.0 );
 
@@ -10,7 +14,7 @@ internal val __color_vertex = """
 
 #ifdef USE_COLOR
 
-	vColor.xyz *= color.xyz;
+	vColor *= color;
 
 #endif
 

--- a/examples/src/main/kotlin/info/laht/threekt/examples/geometries/BufferGeometryExample.kt
+++ b/examples/src/main/kotlin/info/laht/threekt/examples/geometries/BufferGeometryExample.kt
@@ -1,0 +1,182 @@
+package info.laht.threekt.examples.geometries
+
+import info.laht.threekt.Colors
+import info.laht.threekt.Side
+import info.laht.threekt.Window
+import info.laht.threekt.cameras.PerspectiveCamera
+import info.laht.threekt.core.BufferGeometry
+import info.laht.threekt.core.Clock
+import info.laht.threekt.core.FloatBufferAttribute
+import info.laht.threekt.lights.AmbientLight
+import info.laht.threekt.lights.DirectionalLight
+import info.laht.threekt.materials.MeshPhongMaterial
+import info.laht.threekt.math.Color
+import info.laht.threekt.math.Vector3
+import info.laht.threekt.objects.Mesh
+import info.laht.threekt.renderers.GLRenderer
+import info.laht.threekt.scenes.Fog
+import info.laht.threekt.scenes.Scene
+
+object BufferGeometryExample {
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+
+        Window(antialias = 4).use { canvas ->
+
+            val renderer = GLRenderer(canvas.size)
+
+            val camera = PerspectiveCamera(27, canvas.aspect, 1, 3500)
+            camera.position.z = 2750F
+
+            val scene = Scene().apply {
+                setBackground(0x050505)
+                fog = Fog(0x050505, 2000, 3500)
+            }
+
+            scene.add(AmbientLight(0x444444))
+
+            val light1 = DirectionalLight(0xffffff, 0.5)
+            light1.position.set(1, 1, 1)
+            scene.add(light1)
+
+            val light2 = DirectionalLight(0xffffff, 1.5)
+            light2.position.set(0, -1, 0)
+            scene.add(light2)
+
+            val triangles = 160000
+
+            val geometry = BufferGeometry()
+
+            val positions = ArrayList<Float>(triangles * (3 * 3))
+            val normals = ArrayList<Float>(triangles * (3 * 3))
+            val colors = ArrayList<Float>(triangles * (3 * 4))
+
+            val color = Color()
+
+            val n = 800F
+            val n2 = n / 2    // triangles spread in the cube
+            val d = 12F
+            val d2 = d / 2    // individual triangle size
+
+            val pA = Vector3()
+            val pB = Vector3()
+            val pC = Vector3()
+
+            val cb = Vector3()
+            val ab = Vector3()
+
+            for (i in 0 until triangles) {
+
+                // positions
+
+                val x = Math.random().toFloat() * n - n2
+                val y = Math.random().toFloat() * n - n2
+                val z = Math.random().toFloat() * n - n2
+
+                val ax = x + Math.random().toFloat() * d - d2
+                val ay = y + Math.random().toFloat() * d - d2
+                val az = z + Math.random().toFloat() * d - d2
+
+                val bx = x + Math.random().toFloat() * d - d2
+                val by = y + Math.random().toFloat() * d - d2
+                val bz = z + Math.random().toFloat() * d - d2
+
+                val cx = x + Math.random().toFloat() * d - d2
+                val cy = y + Math.random().toFloat() * d - d2
+                val cz = z + Math.random().toFloat() * d - d2
+
+                positions.add(ax)
+                positions.add(ay)
+                positions.add(az)
+                positions.add(bx)
+                positions.add(by)
+                positions.add(bz)
+                positions.add(cx)
+                positions.add(cy)
+                positions.add(cz)
+
+                // flat face normals
+
+                pA.set(ax, ay, az)
+                pB.set(bx, by, bz)
+                pC.set(cx, cy, cz)
+
+                cb.subVectors(pC, pB)
+                ab.subVectors(pA, pB)
+                cb.cross(ab)
+
+                cb.normalize()
+
+                val nx = cb.x
+                val ny = cb.y
+                val nz = cb.z
+
+                normals.add(nx)
+                normals.add(ny)
+                normals.add(nz)
+                normals.add(nx)
+                normals.add(ny)
+                normals.add(nz)
+                normals.add(nx)
+                normals.add(ny)
+                normals.add(nz)
+
+                // colors
+
+                val vx = (x / n) + 0.5F
+                val vy = (y / n) + 0.5F
+                val vz = (z / n) + 0.5F
+
+                color.set(vx, vy, vz)
+
+                val alpha = Math.random().toFloat()
+
+                colors.add(color.r)
+                colors.add(color.g)
+                colors.add(color.b)
+                colors.add(alpha)
+                colors.add(color.r)
+                colors.add(color.g)
+                colors.add(color.b)
+                colors.add(alpha)
+                colors.add(color.r)
+                colors.add(color.g)
+                colors.add(color.b)
+                colors.add(alpha)
+
+            }
+
+            geometry.attributes["position"] = FloatBufferAttribute(positions.toFloatArray(), 3)
+            geometry.attributes["normal"] = FloatBufferAttribute(normals.toFloatArray(), 3)
+            geometry.attributes["color"] = FloatBufferAttribute(colors.toFloatArray(), 4)
+
+            geometry.computeBoundingSphere()
+
+            val material = MeshPhongMaterial().apply {
+                color.set(0xaaaaaa)
+                specular.set(0xffffff)
+                shininess = 250F
+                side = Side.Double
+                vertexColors = Colors.Vertex
+                transparent = true
+            }
+
+            val mesh = Mesh(geometry, material)
+            scene.add(mesh)
+
+            val clock = Clock()
+            canvas.animate {
+
+                mesh.rotation.x += clock.getDelta() * 0.25F
+                mesh.rotation.y += clock.getDelta() * 0.5F
+
+                renderer.render(scene, camera)
+
+            }
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Hey, back at this again :)

This feature was introduced in version [r127](https://github.com/mrdoob/three.js/releases/tag/r127)

[Example](https://threejs.org/examples/?q=buffergeo#webgl_buffergeometry) included. Alpha set to `0.1` looks like this:

![idea64_NOgpNknG62](https://user-images.githubusercontent.com/12080880/209736009-af3afc98-66b1-4d76-abe8-effa33114f0b.png)

