### PR TITLE
Update scissor area in the GL state when scissor area is updated.

### DIFF
--- a/core/src/main/kotlin/info/laht/threekt/renderers/GLRenderer.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/GLRenderer.kt
@@ -148,6 +148,7 @@ class GLRenderer(
 
     fun setScissor(x: Int, y: Int, width: Int, height: Int) {
         scissor.set(x, y, width, height)
+        state.scissor(currentScissor.copy(scissor).multiplyScalar(pixelRatio).floor())
     }
 
     fun setScissorTest(boolean: Boolean) {


### PR DESCRIPTION
Fix for https://github.com/markaren/three.kt/issues/81

threejs code: https://github.com/mrdoob/three.js/blob/dev/src/renderers/WebGLRenderer.js#L516